### PR TITLE
fix(refine-log-filtering) Filter out specific logs #WPB-11179

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     kotlin("jvm") version "1.5.30"
     application
     distribution
-    id("net.nemerosa.versioning") version "2.14.0"
+    id("net.nemerosa.versioning") version "3.1.0"
 }
 
 group = "com.wire.bots.polls"

--- a/src/main/kotlin/com/wire/bots/polls/dto/roman/Message.kt
+++ b/src/main/kotlin/com/wire/bots/polls/dto/roman/Message.kt
@@ -69,11 +69,17 @@ data class Message(
      * Type of the file
      */
     val mimeType: String?,
+
 ) {
     data class Text(
         val data: String,
         val mentions: List<Mention>?
-    )
+
+    ) {
+        override fun toString(): String {
+            return "Text(mentions=$mentions)"
+        }
+    }
 
     /**
      * Poll representation for the proxy.
@@ -97,7 +103,18 @@ data class Message(
          * Id of the button when it was clicked on.
          */
         val offset: Int?
-    )
+    ) {
+        override fun toString(): String {
+            return "PollObjectMessage(id='$id', buttons=$buttons, offset=$offset)"
+        }
+    }
+
+    /**
+     * Avoid printing out the token by mistake if object is printed.
+     */
+    override fun toString(): String {
+        return "Message(botId='$botId', userId=$userId, conversationId=$conversationId, type='$type', messageId=$messageId, text=$text, refMessageId=$refMessageId, reaction=$reaction, image=$image, handle=$handle, locale=$locale, poll=$poll, mimeType=$mimeType)"
+    }
 }
 
 /* JSON from the swagger

--- a/src/main/kotlin/com/wire/bots/polls/setup/HttpClient.kt
+++ b/src/main/kotlin/com/wire/bots/polls/setup/HttpClient.kt
@@ -43,4 +43,4 @@ private val Logger.Companion.TRACE: Logger
         }
     }
 
-private val blockedWordList = listOf("Authorization", "token", "Bearer", "text")
+private val blockedWordList = listOf("Authorization", "token", "Bearer")

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -27,6 +27,7 @@
 
     <logger name="org.eclipse.jetty" level="INFO"/>
     <logger name="io.netty" level="INFO"/>
+    <logger name="org.jetbrains.exposed" level="INFO"/>
 
     <logger name="com.wire" level="TRACE"/>
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Refine log filtering

### Causes (Optional)

HTTP client and server had no restriction on what they logged

### Solutions

Explicitly avoid logging certain lines

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
